### PR TITLE
Update Readme to point to Strapi Discord instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ module.exports = [
 ## Links
 
 - [Strapi website](http://strapi.io/)
-- [Strapi community on Slack](http://slack.strapi.io)
+- [Strapi community on Discord](http://discord.strapi.io)
 - [Strapi news on Twitter](https://twitter.com/strapijs)
 - [Strapi docs about upload](https://docs.strapi.io/developer-docs/latest/getting-started/introduction.html#open-source-contribution)
 


### PR DESCRIPTION
Thank you for this provider fork, just recommended it to one of our community members. Figured I'd update your readme to point towards our Discord instead and also thank you for providing an updated provider for our v4 :)

Thank you!